### PR TITLE
Fixed '‘GHC.Base’ does not export ‘Any’' error

### DIFF
--- a/tower/src/Ivory/Tower/Types/ChanMap.hs
+++ b/tower/src/Ivory/Tower/Types/ChanMap.hs
@@ -11,7 +11,7 @@ module Ivory.Tower.Types.ChanMap
   ) where
 
 import qualified Data.Map as Map
-import GHC.Prim (Any)
+import GHC.Base (Any)
 import Ivory.Language
 import qualified Ivory.Tower.AST as AST
 import Ivory.Tower.Types.Chan

--- a/tower/tower.cabal
+++ b/tower/tower.cabal
@@ -63,7 +63,6 @@ library
                         base-compat >= 0.6,
                         monadLib,
                         containers,
-                        ghc-prim,
                         mainland-pretty >= 0.4.0.0,
                         text,
                         filepath,


### PR DESCRIPTION
GHC.Prim no longer exports Any, GHC.Base does.